### PR TITLE
Bug fix for user path issue.

### DIFF
--- a/install-cloud-sdk-build-task/README.md
+++ b/install-cloud-sdk-build-task/README.md
@@ -1,0 +1,12 @@
+# ![GCP][GCPLogo] Install Cloud Sdk Build Task
+
+This task finds or installs the [Google Cloud SDK][CloudSdk].
+It can then do some basic configuration.
+
+## Usage
+
+If the Google Cloud SDK is already installed for all users on the build agent,
+this task is unnecessary. If, however, the Google Cloud SDK is installed for
+the build agent user only, or not installed at all, you can use this task to find
+or install it. Use this task before calling any other tasks that require the Google
+Cloud SDK.

--- a/install-cloud-sdk-build-task/install-cloud-sdk-build-task.pssproj
+++ b/install-cloud-sdk-build-task/install-cloud-sdk-build-task.pssproj
@@ -27,6 +27,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Content Include="icon.png" />
     <Content Include="manifest.json" />
     <Content Include="task.json" />
   </ItemGroup>

--- a/install-cloud-sdk-build-task/install-cloud-sdk-build-task.pssproj
+++ b/install-cloud-sdk-build-task/install-cloud-sdk-build-task.pssproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Content Include="icon.png" />
     <Content Include="manifest.json" />
+    <Content Include="README.md" />
     <Content Include="task.json" />
   </ItemGroup>
   <ItemGroup>

--- a/install-cloud-sdk-build-task/task.json
+++ b/install-cloud-sdk-build-task/task.json
@@ -27,6 +27,7 @@
       "name": "AllowReporting",
       "label": "Send anonymous usage statistics to Google",
       "type": "boolean",
+      "defaultValue": false,
       "required": true,
       "helpMarkDown": "Help make Google Cloud SDK better by automatically sending [anonymous usage statistics](https://cloud.google.com/sdk/usage-statistics) to Google."
     },
@@ -59,14 +60,6 @@
       "helpMarkDown": "The name of the configuration to create or activate."
     },
     {
-      "name": "UpdatePath",
-      "label": "Update Path",
-      "type": "boolean",
-      "defaultValue": "true",
-      "required": true,
-      "helpMarkDown": "If true, will add the Cloud SDK to the agent user's path environment variable."
-    },
-    {
       "name": "InstallPath",
       "label": "Install Path",
       "type": "string",
@@ -78,9 +71,19 @@
       "name": "ForceInstall",
       "label": "Force Install",
       "type": "boolean",
-      "defaultValue": "false",
+      "defaultValue": false,
       "required": true,
+      "groupName": "advanced",
       "helpMarkDown": "Check this to force an install of the Cloud SDK even if it already exists on the path."
+    },
+    {
+      "name": "CleanInstallPath",
+      "label": "Clean Install Path",
+      "type": "boolean",
+      "defaultValue": false,
+      "required": true,
+      "groupName": "advanced",
+      "helpMarkDown": "Check this to remove files from the target installation path."
     }
   ],
   "execution": {


### PR DESCRIPTION
For some reason, the TFS does not include the user path in the environment. These changes make it so subsequent build tasks can find a cloud sdk installed for just the current user.

Also, add a parameter for cleaning the target folder.