### PR TITLE
Fixes for github.

### DIFF
--- a/DETAILS.md
+++ b/DETAILS.md
@@ -3,7 +3,8 @@
 This extension provides a service endpoint and build tasks to make deploying to
 Google Cloud Platform a breeze.
 
-[TODO(przybjw)]:#(Validate on site documentaion link)
+[TODO(przybjw)]: # (Validate on site documentaion link)
+
 Quickstart and How-To documentation can be found at
 https://cloud.google.com/tools/cloud-tools-tfs/docs/community
 
@@ -31,14 +32,18 @@ The extension installs the following tasks:
   ![Deploy tasks](images/screenshots/DeployTasksCatalog.png)
   ![Package tasks](images/screenshots/CloudContainerBuildCatalog.png)
   ![Utility tasks](images/screenshots/GetGcePasswordCatalog.png)
-  - **[Deploy to Google App Engine](deploy-gae-build-task/README.md)**: Deploy ASP.NET Core and other application to [Google App Engine][AppEngine]
-  - **[Deploy to Google Container Engine](deploy-gke-build-task/README.md)**: Deploy ASP.NET Core and other applications to [Google Container Engine][ContainerEngine]
-  - **[Google Cloud Container Builder](container-build-task/README.md)**: Build Docker container images with [Google Container Builder][ContainerBuilder]
-  - **[Get Google Compute VM password](set-login-build-task/README.md)**: Gets the IP address and user password for a [Google Compute Engine][ComputeEngine] virtual machine running windows.
-
+  - **[Deploy to Google App Engine][deploy-gae]**: Deploy ASP.NET Core and other application to [Google App Engine][AppEngine]
+  - **[Deploy to Google Container Engine][deploy-gke]**: Deploy ASP.NET Core and other applications to [Google Container Engine][ContainerEngine]
+  - **[Google Cloud Container Builder][container-build]**: Build Docker container images with [Google Container Builder][ContainerBuilder]
+  - **[Get Google Compute VM password][set-login-password]**: Gets the IP address and user password for a [Google Compute Engine][ComputeEngine] virtual machine running windows.
 
 [CloudSdk]: https://cloud.google.com/sdk/downloads
 [AppEngine]: https://cloud.google.com/appengine
 [ContainerEngine]: https://cloud.google.com/container-engine
 [ContainerBuilder]: https://cloud.google.com/container-builder
 [ComputeEngine]: https://cloud.google.com/compute
+
+[deploy-gae]: https://github.com/GoogleCloudPlatform/google-cloud-tfs/blob/master/deploy-gae-build-task/README.md
+[deploy-gke]: https://github.com/GoogleCloudPlatform/google-cloud-tfs/blob/master/deploy-gke-build-task/README.md
+[container-build]: https://github.com/GoogleCloudPlatform/google-cloud-tfs/blob/master/container-build-task/README.md
+[set-login-password]: https://github.com/GoogleCloudPlatform/google-cloud-tfs/blob/master/set-login-build-task/README.md

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ For Documentation on useing the extension, see [DETAILS.md](DETAILS.md)
 The latest stable version can be found on the
 [Visual Studio Marketplace][Marketplace].
 
-[TODO(przybjw)]:#(change to CI build server)
+[TODO(przybjw)]: # (change to CI build server)
+
 The latest development version is not available as a package.
 
 You can [build the vsix package from source](#Build), and then upload and
@@ -46,7 +47,7 @@ Questions can be asked on StackOverflow
   - [Ask a question][StackOverflowAsk]
   - [Browse asked questions][StackOverflowBrowse]
 
-[GCPLogo]: images/cloud_128x128.png
+[GCPLogo]: images/cloud_64x64.png
 [PowerShell]: https://msdn.microsoft.com/powershell
 [Node]: https://nodejs.org
 [npm]: https://www.npmjs.com
@@ -54,12 +55,9 @@ Questions can be asked on StackOverflow
 [tfs-cli]: https://github.com/Microsoft/tfs-cli
 [CloudSdk]: https://cloud.google.com/sdk/downloads
 
-[TODO(przybjw)]:#(verify GitHub issue tracker link.)
 [GitHubIssues]: https://github.com/GoogleCloudPlatform/google-cloud-tfs/issues
 
-[TODO(przybjw)]:#(verify marketplace link.)
-[Marketplace]: https://marketplace.visualstudio.com/items?itemName=GoogleCloudTools.CloudToolsTFS
+[Marketplace]: https://marketplace.visualstudio.com/items?itemName=GoogleCloudTools.google-cloud-tfs
 
-[TODO(przybjw)]:#(verify StackOverflow tag.)
 [StackOverflowAsk]: http://stackoverflow.com/questions/ask?tags=google-cloud-tfs
 [StackOverflowBrowse]: http://stackoverflow.com/questions/tagged/google-cloud-tfs

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ install the extension from the extension management page of TFS or VSTS.
 
 Execute build script `./build/BuildExtension.ps1`. It will download needed
 modules, build the common files and build tasks, and then package everything
-into `./bin/Google Clout Tools.google-cloud-tfs-<version>.vsix`.
+into `./bin/Google Cloud Tools.google-cloud-tfs-<version>.vsix`.
 
 ## Contributing
 

--- a/cloud-tools-tfs.sln
+++ b/cloud-tools-tfs.sln
@@ -16,7 +16,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		DETAILS.md = DETAILS.md
 		LICENSE = LICENSE
 		manifest.json = manifest.json
-		manifest.schema.json = manifest.schema.json
 		README.md = README.md
 		tsconfig.json = tsconfig.json
 	EndProjectSection
@@ -34,6 +33,8 @@ EndProject
 Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "container-build-task", "container-build-task\container-build-task.njsproj", "{86DB8657-6D59-4455-9F30-81343CBE7CBC}"
 EndProject
 Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "deploy-gke-build-task", "deploy-gke-build-task\deploy-gke-build-task.njsproj", "{D839A77D-05FA-4180-9ECB-E44C987599F2}"
+EndProject
+Project("{F5034706-568F-408A-B7B3-4D38C6DB8A32}") = "install-cloud-sdk-build-task", "install-cloud-sdk-build-task\install-cloud-sdk-build-task.pssproj", "{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -61,6 +62,10 @@ Global
 		{D839A77D-05FA-4180-9ECB-E44C987599F2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D839A77D-05FA-4180-9ECB-E44C987599F2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D839A77D-05FA-4180-9ECB-E44C987599F2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CAFC0C6-A428-4D30-A9F9-700E829FEA51}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/common/exec-options.ts
+++ b/common/exec-options.ts
@@ -17,12 +17,15 @@
  * calls to gcloud and kubectl.
  * @author JimWP@google.com (Jim Przybylinski)
  */
+
 import * as fs from 'fs';
 import * as stream from 'stream';
 import * as task from 'vsts-task-lib/task';
 import {IExecOptions} from 'vsts-task-lib/toolrunner';
 
 import * as sc from './strings';
+
+import WritableStream = NodeJS.WritableStream;
 
 /**
  * This function creates exec options useful for calls to gcloud. It
@@ -35,7 +38,7 @@ import * as sc from './strings';
 export function getDefaultExecOptions(): IExecOptions {
   return {
     windowsVerbatimArguments: true,
-    errStream: process.stdout as stream.Writable,
+    errStream: process.stdout as WritableStream,
     env: {
       'CLOUDSDK_METRICS_ENVIRONMENT': 'cloud-tools-tfs',
       'CLOUDSDK_METRICS_ENVIRONMENT_VERSION': '0.0.1',

--- a/container-build-task/README.md
+++ b/container-build-task/README.md
@@ -32,7 +32,7 @@ the service account to deploy it with.
 
 
 
-[GCPLogo]: ../images/cloud_128x128.png
+[GCPLogo]: ../images/cloud_64x64.png
 [Build]: ../images/screenshots/dotnet-core-container-build-process.png
 [GcbTaskParams]: ../images/screenshots/container-build-inputs.png
 [AspNetCore]: https://www.asp.net/core

--- a/container-build-task/container-build.ts
+++ b/container-build-task/container-build.ts
@@ -25,6 +25,8 @@ import {Writable} from 'stream';
 
 import * as helper from './container-build-helper';
 
+import WritableStream = NodeJS.WritableStream;
+
 /**
  * Runs the script for the container-build-task
  */
@@ -104,7 +106,7 @@ async function run(): Promise<void> {
   }
 
   const execOptions: IExecOptions = getQuietExecOptions();
-  execOptions.errStream = process.stdout as Writable;
+  execOptions.errStream = (process.stdout as WritableStream) as Writable;
 
   await endpoint.usingAsync(async () => {
     await gcloud.exec(execOptions);

--- a/deploy-gae-build-task/README.md
+++ b/deploy-gae-build-task/README.md
@@ -37,8 +37,7 @@ immediately.
 resources, but prevents a quick rollback.
 
 
-
-[GCPLogo]: ../images/cloud_128x128.png
+[GCPLogo]: ../images/cloud_64x64.png
 [Build]: ../images/screenshots/dotnet-core-build-process.png
 [GaeTaskParams]: ../images/screenshots/deploy-gae-inputs.png
 [GAE]: https://cloud.google.com/appengine

--- a/deploy-gae-build-task/task.json
+++ b/deploy-gae-build-task/task.json
@@ -68,7 +68,7 @@
       "defaultValue": false,
       "required": true,
       "groupName": "copy",
-      "helpMarkDown": "Select this option if you need the task to copy your YAML file to yoru deployment source folder."
+      "helpMarkDown": "Select this option if you need the task to copy your YAML file to your deployment source folder."
     },
     {
       "name": "sourceFolder",

--- a/deploy-gke-build-task/README.md
+++ b/deploy-gke-build-task/README.md
@@ -47,8 +47,7 @@ file with the same name as this input will be updated.
 the new value of the configuration will be output to the build console.
 
 
-
-[GCPLogo]: ../images/cloud_128x128.png
+[GCPLogo]: ../images/cloud_64x64.png
 [DeployByValueParameters]: ../images/screenshots/deploy-gke-value-inputs.png
 [DeployByConfigParameters]: ../images/screenshots/deploy-gke-config-inputs.png
 [Kubernetes]: https://kubernetes.io

--- a/set-login-build-task/README.md
+++ b/set-login-build-task/README.md
@@ -32,7 +32,7 @@ an ASP.NET application to your Google Compute VMs.
 
 
 
-[GCPLogo]: ../images/cloud_128x128.png
+[GCPLogo]: ../images/cloud_64x64.png
 [SetLoginParameters]: ../images/screenshots/set-login-inputs.png
 [GceBuildProcess]: ../images/screenshots/GceBuildProcess.png
 [WinRmTasks]: https://marketplace.visualstudio.com/items?itemName=ms-vscs-rm.iiswebapp


### PR DESCRIPTION
There are a few changes here.

Fix a few typos.
Use a more correctly scaled icon.
Fix a couple of compile errors caused by updated @types/node packages.
Try to use the right markdown comment syntax.