### PR TITLE
Update README.md with missing build dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Questions can be asked on StackOverflow
 
   - [PowerShell][PowerShell]: Installed by default on modern windows platforms.
   - [Node.js][Node]: Download and install from the website.
-  - [npm][npm]: Should be installed with the Node.js install.
+  - [npm][npm]: Installed along with Node.js.
   - [TypeScript][TypeScript]: Install with `npm install -g typescript`
   - [tfx][tfs-cli]: The tfs cli. Install with `npm install -g tfx-cli`
+  - [mocha][mocha]: A JavaScript test runner. `npm install -g mocha`
+  - [ts-node]: Used by mocha to run TypeScript directly. `npm install -g ts-node`
   - [nyc][nyc]: The Istanbul code coverage tool. Install with `npm install -g nyc`
 
 ### Build Script
@@ -55,6 +57,8 @@ into `./bin/Google Cloud Tools.google-cloud-tfs-<version>.vsix`.
 [npm]: https://www.npmjs.com
 [TypeScript]: https://www.typescriptlang.org
 [tfs-cli]: https://github.com/Microsoft/tfs-cli
+[mocha]: https://mochajs.org/
+[ts-node]: https://www.npmjs.com/package/ts-node
 [nyc]: https://istanbul.js.org/
 [CloudSdk]: https://cloud.google.com/sdk/downloads
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@ This repository contains an extension for Team Foundation server and Visual
 Studio Team Services. The extension provides a new service endpoint and several
 build tasks for interacting with Google Cloud Platform.
 
-## Documentation
-
-For Documentation on using the extension, see [DETAILS.md](DETAILS.md)
-
 ## Installation
 
 The latest stable version can be found on the
@@ -20,6 +16,10 @@ The latest development version is available from [AppVeyor][AppVeyor].
 
 You can [build the vsix package from source](#Build), and then upload and
 install the extension from the extension management page of TFS.
+
+## Documentation
+
+For Documentation on using the extension, see [DETAILS.md](DETAILS.md)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/hu7qlgxrh2j0i35y/branch/master?svg=true)](https://ci.appveyor.com/project/ILMTitan/google-cloud-tfs/branch/master)
-[![codecov](https://codecov.io/gh/GoogleCloudPlatform/google-cloud-tfs/branch/master/graph/badge.svg)](https://codecov.io/gh/GoogleCloudPlatform/google-cloud-tfs)
+[![Build status][AppVeyorBadge]][AppVeyorLink]
+[![codecov][CodeCovBadge]][CodeCovLink]
 
-# ![GCPLogo][GCPLogo] Cloud Tools for Team Foundation Server
+# ![GcpLogo][GcpLogo] Cloud Tools for Team Foundation Server
 
 This repository contains an extension for Team Foundation server and Visual
 Studio Team Services. The extension provides a new service endpoint and several
@@ -16,20 +16,28 @@ For Documentation on using the extension, see [DETAILS.md](DETAILS.md)
 The latest stable version can be found on the
 [Visual Studio Marketplace][Marketplace] or in the [GitHub Releases][GitHubReleases]
 
-The latest development version is available from [AppVeyor][Appveyor].
+The latest development version is available from [AppVeyor][AppVeyor].
 
 You can [build the vsix package from source](#Build), and then upload and
 install the extension from the extension management page of TFS.
+
+## Support
+
+Issues are tracked on [GitHub][GitHubIssues].
+Questions can be asked on StackOverflow
+  - [Ask a question][StackOverflowAsk]
+  - [Browse asked questions][StackOverflowBrowse]
 
 ## Build
 
 ### Prerequisites
 
-  - [PowerShell][PowerShell]. Installed by default on modern windows platforms.
-  - [Node.js][Node]. Download and install from the website.
-  - [npm][npm]. Should be installed with the Node.js install.
-  - [TypeScript][TypeScript]. Install with `npm install -g typescript`
-  - [tfx][tfs-cli] The tfs cli. Install with `npm install -g tfx-cli`
+  - [PowerShell][PowerShell]: Installed by default on modern windows platforms.
+  - [Node.js][Node]: Download and install from the website.
+  - [npm][npm]: Should be installed with the Node.js install.
+  - [TypeScript][TypeScript]: Install with `npm install -g typescript`
+  - [tfx][tfs-cli]: The tfs cli. Install with `npm install -g tfx-cli`
+  - [nyc][nyc]: The Istanbul code coverage tool. Install with `npm install -g nyc`
 
 ### Build Script
 
@@ -41,19 +49,13 @@ into `./bin/Google Cloud Tools.google-cloud-tfs-<version>.vsix`.
 
  See our [Contributing guide](CONTRIBUTING.md)
 
-## Support
-
-Issues are tracked on [GitHub][GitHubIssues].
-Questions can be asked on StackOverflow
-  - [Ask a question][StackOverflowAsk]
-  - [Browse asked questions][StackOverflowBrowse]
-
-[GCPLogo]: images/cloud_64x64.png
+[GcpLogo]: images/cloud_64x64.png
 [PowerShell]: https://msdn.microsoft.com/powershell
 [Node]: https://nodejs.org
 [npm]: https://www.npmjs.com
 [TypeScript]: https://www.typescriptlang.org
 [tfs-cli]: https://github.com/Microsoft/tfs-cli
+[nyc]: https://istanbul.js.org/
 [CloudSdk]: https://cloud.google.com/sdk/downloads
 
 [GitHubIssues]: https://github.com/GoogleCloudPlatform/google-cloud-tfs/issues
@@ -61,7 +63,13 @@ Questions can be asked on StackOverflow
 
 [Marketplace]: https://marketplace.visualstudio.com/items?itemName=GoogleCloudTools.google-cloud-tfs
 
-[Appveyor]: https://ci.appveyor.com/project/ILMTitan/google-cloud-tfs/build/artifacts
+[AppVeyor]: https://ci.appveyor.com/project/ILMTitan/google-cloud-tfs/build/artifacts
+[AppVeyorBadge]: https://ci.appveyor.com/api/projects/status/hu7qlgxrh2j0i35y/branch/master?svg=true
+[AppVeyorLink]: https://ci.appveyor.com/project/ILMTitan/google-cloud-tfs/branch/master
+
+[CodeCovBadge]: https://codecov.io/gh/GoogleCloudPlatform/google-cloud-tfs/branch/master/graph/badge.svg
+[CodeCovLink]: https://codecov.io/gh/GoogleCloudPlatform/google-cloud-tfs
 
 [StackOverflowAsk]: http://stackoverflow.com/questions/ask?tags=google-cloud-tfs
 [StackOverflowBrowse]: http://stackoverflow.com/questions/tagged/google-cloud-tfs
+


### PR DESCRIPTION
Add the nyc as a global build dependency.

Reorder the sections to: Install, Docs, Support, Build, Contribute.